### PR TITLE
Metadata for Mentawai 1933

### DIFF
--- a/barrier-island-Holle-list-2023-05-24.Rproj
+++ b/barrier-island-Holle-list-2023-05-24.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 665175ac-3e0d-4d5a-b75f-4c1cfc55542a
 
 RestoreWorkspace: Default
 SaveWorkspace: Default

--- a/data-output/mentawai1933_general-info.tsv
+++ b/data-output/mentawai1933_general-info.tsv
@@ -1,0 +1,17 @@
+query	response
+Language/dialect	Mentawai, southern dialect, called Ngangan Sakalagan
+Number of the list	208
+Mentioned in	JB. 1934
+Year of investigation	1933
+Place of investigation	Muara Sibirut (Mentawai islands)
+Does this place lie in the area where the language is spoken?	-
+Name of investigator	J.H. Tijmann - Commander of the Mentawai islands (1st Lieutenant of the Infantry)
+Name of investigator	Enos Tamboenan - clerk 1st grade in the local government office (Batak)
+Name of informant	Enos Tamboenan
+Sex	Male
+Age	45 years
+Status	Clerk 1st grade B.B.
+Ethnic group	Batak
+Mother tongue	Batak language
+Talent for languages	excellent
+Condition of speech organs	good

--- a/merge-to-nbl-mentawai.R
+++ b/merge-to-nbl-mentawai.R
@@ -10,6 +10,17 @@ holle_1931 <- read_tsv("https://raw.githubusercontent.com/engganolang/digitised-
 
 mtw33_words <- read_lines("plaintexts/mentawai1933.txt")
 
+# Processing metadata ====
+metadata_tag <- str_which(mtw33_words, "metadata\\>")
+metadata <- mtw33_words[(metadata_tag[1]+1):(metadata_tag[2]-1)]
+gen_info <- metadata |> 
+  tibble() |> 
+  separate_wider_delim(metadata, 
+                       delim = "\\t", 
+                       names = c("query", "response")) |> 
+  separate_longer_delim(response, regex("\\s?\\;\\s?"))
+write_tsv(gen_info, "data-output/mentawai1933_general-info.tsv")
+
 # Processing the word list =====
 wlist_tags <- str_which(mtw33_words, "wordlist\\>")
 wlist_1931_tags <- str_which(mtw33_words, "<\\/?wlist")

--- a/plaintexts/mentawai1933.txt
+++ b/plaintexts/mentawai1933.txt
@@ -1,34 +1,19 @@
 <metadata>
-Language/dialect
-Number of the list
-Mentioned in
-Year of investigation
-Place of investigation
-Does this place lie in the area where the language is spoken?
-Name of investigator
-Name of informant
-Sex
-Age
-Status
-Ethnic group
-Mother tongue
-Talent for languages
-Condition of speech organs
-Mentawai, southern dialect, called Ngangan Sakalagan
-208
-JB. 1934
-1933
-Muara Sibirut (Mentawai islands)
--
-J.H. Tijmann - Commander of the Mentawai islands (1st Lieutenant of the Infantry) ; Enos Tamboenan - clerk 1st grade in the local government office (Batak)
-Enos Tamboenan
-Male
-45 years
-Clerk 1st grade B.B.
-Batak
-Batak language
-excellent
-good
+Language/dialect\tMentawai, southern dialect, called Ngangan Sakalagan
+Number of the list\t208
+Mentioned in\tJB. 1934
+Year of investigation\t1933
+Place of investigation\tMuara Sibirut (Mentawai islands)
+Does this place lie in the area where the language is spoken?\t-
+Name of investigator\tJ.H. Tijmann - Commander of the Mentawai islands (1st Lieutenant of the Infantry) ; Enos Tamboenan - clerk 1st grade in the local government office (Batak)
+Name of informant\tEnos Tamboenan
+Sex\tMale
+Age\t45 years
+Status\tClerk 1st grade B.B.
+Ethnic group\tBatak
+Mother tongue\tBatak language
+Talent for languages\texcellent
+Condition of speech organs\tgood
 </metadata>
 <wordlist>
 1. toeboe


### PR DESCRIPTION
This 'edits' add code to process the metadata information in the plain text.\nThe Metadata for Mentawai 1933 is transformed into a tibble.